### PR TITLE
adding blog post - setup-serilog-in-net6-as-logging-provider

### DIFF
--- a/docs/dotnet/logging.md
+++ b/docs/dotnet/logging.md
@@ -4,6 +4,7 @@
 - [Serilog Docs](https://github.com/serilog/serilog/wiki)
 
 ## 📝 Articles
+- [Set up Serilog in .NET 6 as a logging provider](https://rmauro.dev/setup-serilog-in-net6-as-logging-provider/)
 - [Logging in .NET Core and ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging)
 - [Logging in .NET](https://docs.microsoft.com/en-us/dotnet/core/extensions/logging)
 - [Setup Serilog for Asp.Net Core](https://github.com/serilog/serilog-aspnetcore#readme)

--- a/docs/dotnet/logging.md
+++ b/docs/dotnet/logging.md
@@ -4,7 +4,6 @@
 - [Serilog Docs](https://github.com/serilog/serilog/wiki)
 
 ## 📝 Articles
-- [Set up Serilog in .NET 6 as a logging provider](https://rmauro.dev/setup-serilog-in-net6-as-logging-provider/)
 - [Logging in .NET Core and ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging)
 - [Logging in .NET](https://docs.microsoft.com/en-us/dotnet/core/extensions/logging)
 - [Setup Serilog for Asp.Net Core](https://github.com/serilog/serilog-aspnetcore#readme)
@@ -63,6 +62,7 @@
 - [How to turn off Serilog?](https://stackoverflow.com/questions/30849166/how-to-turn-off-serilog)
 - [MediatR Pipeline Behaviour in ASP.NET Core – Logging and Validation](https://codewithmukesh.com/blog/mediatr-pipeline-behaviour/)
 - [Improving logging performance with source generators](https://andrewlock.net/exploring-dotnet-6-part-8-improving-logging-performance-with-source-generators/)
+- [Set up Serilog in .NET 6 as a logging provider](https://rmauro.dev/setup-serilog-in-net6-as-logging-provider/)
 
 ## 📹 Videos
 - [Logging into Elasticsearch using Serilog and viewing logs in Kibana | .NET Core Tutorial](https://www.youtube.com/watch?v=0acSdHJfk64)


### PR DESCRIPTION
This blog post describes how to *Set up Serilog in .NET 6 as a logging provider*, which is different from previous versions.

It also gives some tips on how to use `Serilog` and get started

I hope it is be useful
