### PR TITLE
remove the parameter null-checking youtube link

### DIFF
--- a/docs/csharp/versions/11.md
+++ b/docs/csharp/versions/11.md
@@ -2,7 +2,6 @@
 
 ## 📺 Videos
 - [The evolution of Pattern Matching in C# (from version 6 to 10)](https://www.youtube.com/watch?v=MzNHMJCyU40)
-- ~~[C# 11's new operator #Shorts](https://www.youtube.com/watch?v=pFMA6wI2m_w)~~
 - [The evolution of Properties in C# from version 1 to 10)](https://www.youtube.com/watch?v=RqdZCq-2GNM)
 - [C# 11’s new List Patterns are a bit too powerful](https://www.youtube.com/watch?v=z7bW83Xr1R0)
 - [Strings in C# 11 just got a whole lot better](https://www.youtube.com/watch?v=4KXWAgZE8xI)

--- a/docs/csharp/versions/11.md
+++ b/docs/csharp/versions/11.md
@@ -2,7 +2,7 @@
 
 ## 📺 Videos
 - [The evolution of Pattern Matching in C# (from version 6 to 10)](https://www.youtube.com/watch?v=MzNHMJCyU40)
-- [C# 11's new operator #Shorts](https://www.youtube.com/watch?v=pFMA6wI2m_w)
+- ~~[C# 11's new operator #Shorts](https://www.youtube.com/watch?v=pFMA6wI2m_w)~~
 - [The evolution of Properties in C# from version 1 to 10)](https://www.youtube.com/watch?v=RqdZCq-2GNM)
 - [C# 11’s new List Patterns are a bit too powerful](https://www.youtube.com/watch?v=z7bW83Xr1R0)
 - [Strings in C# 11 just got a whole lot better](https://www.youtube.com/watch?v=4KXWAgZE8xI)


### PR DESCRIPTION
"parameter null-checking" has been removed from c#11 . [link](https://devblogs.microsoft.com/dotnet/csharp-11-preview-updates/#remove-parameter-null-checking-from-c-11)